### PR TITLE
feat: show numbered queue for raised hands

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "marked": "18.0.5",
     "mobile-detect": "1.4.5",
     "nosleep.js": "0.12.0",
-    "plugnmeet-protocol-js": "1.3.0",
+    "plugnmeet-protocol-js": "1.3.1-18",
     "react": "19.2.7",
     "react-cool-virtual": "0.7.0",
     "react-dnd": "16.0.1",

--- a/src/components/media-elements/videos/video/raisedHand.tsx
+++ b/src/components/media-elements/videos/video/raisedHand.tsx
@@ -16,9 +16,7 @@ const RaisedHand = ({ userId }: RaisedHandProps) => {
     (state) =>
       participantsSelector.selectById(state, userId)?.metadata.raisedHand,
   );
-  // select primitives so this tile only re-renders when ITS own position
-  // changes or when the count crosses the threshold of 2 — not on every
-  // raise/lower of other participants.
+
   const position = useAppSelector(
     (state) => selectRaisedHandsQueue(state).positions[userId],
   );

--- a/src/components/media-elements/videos/video/raisedHand.tsx
+++ b/src/components/media-elements/videos/video/raisedHand.tsx
@@ -16,14 +16,20 @@ const RaisedHand = ({ userId }: RaisedHandProps) => {
     (state) =>
       participantsSelector.selectById(state, userId)?.metadata.raisedHand,
   );
-  const { positions, count } = useAppSelector(selectRaisedHandsQueue);
+  // select primitives so this tile only re-renders when ITS own position
+  // changes or when the count crosses the threshold of 2 — not on every
+  // raise/lower of other participants.
+  const position = useAppSelector(
+    (state) => selectRaisedHandsQueue(state).positions[userId],
+  );
+  const showNumber = useAppSelector((state) => {
+    const queue = selectRaisedHandsQueue(state);
+    return queue.count >= 2 && !!queue.positions[userId];
+  });
 
   if (!raisedHand) {
     return null;
   }
-
-  const position = positions[userId];
-  const showNumber = count >= 2 && !!position;
 
   return (
     <div className="raised-hand absolute bottom-0 right-4 cursor-pointer w-7 h-7 rounded-full bg-Blue2-500 flex items-center justify-center">

--- a/src/components/media-elements/videos/video/raisedHand.tsx
+++ b/src/components/media-elements/videos/video/raisedHand.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 
 import { useAppSelector } from '../../../../store';
-import { participantsSelector } from '../../../../store/slices/participantSlice';
+import {
+  participantsSelector,
+  selectRaisedHandsQueue,
+} from '../../../../store/slices/participantSlice';
 import { HandsIconSVG } from '../../../../assets/Icons/HandsIconSVG';
 
 interface RaisedHandProps {
@@ -13,13 +16,24 @@ const RaisedHand = ({ userId }: RaisedHandProps) => {
     (state) =>
       participantsSelector.selectById(state, userId)?.metadata.raisedHand,
   );
+  const { positions, count } = useAppSelector(selectRaisedHandsQueue);
+
+  if (!raisedHand) {
+    return null;
+  }
+
+  const position = positions[userId];
+  const showNumber = count >= 2 && !!position;
 
   return (
-    raisedHand && (
-      <div className="raised-hand absolute bottom-0 right-4 cursor-pointer w-7 h-7 rounded-full bg-Blue2-500 flex items-center justify-center">
-        <HandsIconSVG classes="h-4 w-auto" />
-      </div>
-    )
+    <div className="raised-hand absolute bottom-0 right-4 cursor-pointer w-7 h-7 rounded-full bg-Blue2-500 flex items-center justify-center">
+      <HandsIconSVG classes="h-4 w-auto" />
+      {showNumber && (
+        <span className="absolute -top-1.5 -right-1.5 min-w-[16px] h-4 px-1 rounded-full bg-white text-Blue2-500 text-[10px] leading-4 font-semibold text-center">
+          {position}
+        </span>
+      )}
+    </div>
   );
 };
 export default RaisedHand;

--- a/src/components/participants/participant/icons/raiseHand.tsx
+++ b/src/components/participants/participant/icons/raiseHand.tsx
@@ -15,14 +15,20 @@ const RaiseHandIcon = ({ userId }: IRaiseHandIconProps) => {
     (state) =>
       participantsSelector.selectById(state, userId)?.metadata.raisedHand,
   );
-  const { positions, count } = useAppSelector(selectRaisedHandsQueue);
+  // select primitives so this row only re-renders when ITS own position
+  // changes or when the count crosses the threshold of 2 — not on every
+  // raise/lower of other participants.
+  const position = useAppSelector(
+    (state) => selectRaisedHandsQueue(state).positions[userId],
+  );
+  const showNumber = useAppSelector((state) => {
+    const queue = selectRaisedHandsQueue(state);
+    return queue.count >= 2 && !!queue.positions[userId];
+  });
 
   if (!raisedHand) {
     return null;
   }
-
-  const position = positions[userId];
-  const showNumber = count >= 2 && !!position;
 
   return (
     <IconWrapper>

--- a/src/components/participants/participant/icons/raiseHand.tsx
+++ b/src/components/participants/participant/icons/raiseHand.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { useAppSelector } from '../../../../store';
-import { participantsSelector } from '../../../../store/slices/participantSlice';
+import {
+  participantsSelector,
+  selectRaisedHandsQueue,
+} from '../../../../store/slices/participantSlice';
 import { HandsIconSVG } from '../../../../assets/Icons/HandsIconSVG';
 import IconWrapper from './iconWrapper';
 
@@ -12,13 +15,26 @@ const RaiseHandIcon = ({ userId }: IRaiseHandIconProps) => {
     (state) =>
       participantsSelector.selectById(state, userId)?.metadata.raisedHand,
   );
+  const { positions, count } = useAppSelector(selectRaisedHandsQueue);
+
+  if (!raisedHand) {
+    return null;
+  }
+
+  const position = positions[userId];
+  const showNumber = count >= 2 && !!position;
 
   return (
-    raisedHand && (
-      <IconWrapper>
+    <IconWrapper>
+      <div className="relative flex items-center justify-center">
         <HandsIconSVG classes={'h-3 3xl:h-4 w-auto dark:text-white'} />
-      </IconWrapper>
-    )
+        {showNumber && (
+          <span className="absolute -top-2 -right-2 min-w-[14px] h-3.5 px-0.5 rounded-full bg-Blue2-500 text-white text-[9px] leading-[14px] font-semibold text-center">
+            {position}
+          </span>
+        )}
+      </div>
+    </IconWrapper>
   );
 };
 

--- a/src/components/participants/participant/icons/raiseHand.tsx
+++ b/src/components/participants/participant/icons/raiseHand.tsx
@@ -15,9 +15,7 @@ const RaiseHandIcon = ({ userId }: IRaiseHandIconProps) => {
     (state) =>
       participantsSelector.selectById(state, userId)?.metadata.raisedHand,
   );
-  // select primitives so this row only re-renders when ITS own position
-  // changes or when the count crosses the threshold of 2 — not on every
-  // raise/lower of other participants.
+
   const position = useAppSelector(
     (state) => selectRaisedHandsQueue(state).positions[userId],
   );

--- a/src/store/slices/participantSlice.ts
+++ b/src/store/slices/participantSlice.ts
@@ -122,6 +122,7 @@ export const selectRaisedHandsQueue = createSelector(
 export const selectVisibleParticipants = createSelector(
   [
     selectParticipantsForListDisplay,
+    selectRaisedHandsQueue,
     (state: RootState, isAdmin: boolean) => isAdmin,
     (state: RootState, isAdmin: boolean, search: string) => search,
     (
@@ -138,7 +139,14 @@ export const selectVisibleParticipants = createSelector(
       currentUserId: string | undefined,
     ) => currentUserId,
   ],
-  (participants, isAdmin, search, allowViewOtherUsers, currentUserId) => {
+  (
+    participants,
+    queue,
+    isAdmin,
+    search,
+    allowViewOtherUsers,
+    currentUserId,
+  ) => {
     let list = participants.filter(
       (p) =>
         p.name !== '' && p.userId !== 'RECORDER_BOT' && p.userId !== 'RTMP_BOT',
@@ -154,16 +162,31 @@ export const selectVisibleParticipants = createSelector(
       );
     }
 
+    // Raised hands float to the top in queue order (matches the 1/2/3 badges).
+    // Returns 0 for non-raised pairs so the stable sort keeps the baseline name
+    // order (entity adapter sortComparer).
+    const raisedRank = (
+      a: IVisibleParticipantInfo,
+      b: IVisibleParticipantInfo,
+    ) => {
+      const pa = queue.positions[a.userId];
+      const pb = queue.positions[b.userId];
+      if (pa && pb) return pa - pb;
+      if (pa) return -1;
+      if (pb) return 1;
+      return 0;
+    };
+
+    // .sort() mutates the array; `list` is already a filtered copy, so this is safe.
     if (isAdmin) {
-      // .sort() mutates the array, so we work on a copy.
-      return list.sort((a, b) =>
-        a.waitForApproval === b.waitForApproval
-          ? 0
-          : a.waitForApproval
-            ? -1
-            : 1,
-      );
+      // waiting-room users stay on top, then raised hands, then the rest.
+      return list.sort((a, b) => {
+        if (a.waitForApproval !== b.waitForApproval) {
+          return a.waitForApproval ? -1 : 1;
+        }
+        return raisedRank(a, b);
+      });
     }
-    return list;
+    return list.sort(raisedRank);
   },
 );

--- a/src/store/slices/participantSlice.ts
+++ b/src/store/slices/participantSlice.ts
@@ -86,6 +86,39 @@ const selectParticipantsForListDisplay = createSelector(
   },
 );
 
+export interface IRaisedHandsQueue {
+  // userId -> 1-based position in the raise order
+  positions: Record<string, number>;
+  // total number of currently raised hands
+  count: number;
+}
+
+export const selectRaisedHandsQueue = createSelector(
+  [participantsSelector.selectAll],
+  (participants): IRaisedHandsQueue => {
+    const raised = participants
+      .filter((p) => p.metadata?.raisedHand === true)
+      .sort((a, b) => {
+        const at = Number(a.metadata?.raisedHandAt);
+        const bt = Number(b.metadata?.raisedHandAt);
+        if (at !== bt) {
+          return at - bt;
+        }
+        return a.userId.localeCompare(b.userId);
+      });
+
+    const positions: Record<string, number> = {};
+    raised.forEach((p, i) => {
+      positions[p.userId] = i + 1;
+    });
+
+    return { positions, count: raised.length };
+  },
+  {
+    memoizeOptions: { resultEqualityCheck: isEqual },
+  },
+);
+
 export const selectVisibleParticipants = createSelector(
   [
     selectParticipantsForListDisplay,

--- a/src/store/slices/participantSlice.ts
+++ b/src/store/slices/participantSlice.ts
@@ -96,11 +96,20 @@ export interface IRaisedHandsQueue {
 export const selectRaisedHandsQueue = createSelector(
   [participantsSelector.selectAll],
   (participants): IRaisedHandsQueue => {
+    // raisedHandAt is an int64 emitted as a string (jstype=JS_STRING). Coerce
+    // defensively: a missing/invalid value falls back to 0 so the comparator can
+    // never return NaN — a NaN result would violate the Array.sort contract and
+    // produce unstable ordering across JS engines.
+    const raisedAtMs = (p: IParticipant) => {
+      const n = Number(p.metadata?.raisedHandAt);
+      return Number.isNaN(n) ? 0 : n;
+    };
+
     const raised = participants
       .filter((p) => p.metadata?.raisedHand === true)
       .sort((a, b) => {
-        const at = Number(a.metadata?.raisedHandAt);
-        const bt = Number(b.metadata?.raisedHandAt);
+        const at = raisedAtMs(a);
+        const bt = raisedAtMs(b);
         if (at !== bt) {
           return at - bt;
         }

--- a/src/store/slices/participantSlice.ts
+++ b/src/store/slices/participantSlice.ts
@@ -162,23 +162,25 @@ export const selectVisibleParticipants = createSelector(
       );
     }
 
-    // Raised hands float to the top in queue order (matches the 1/2/3 badges).
-    // Returns 0 for non-raised pairs so the stable sort keeps the baseline name
-    // order (entity adapter sortComparer).
-    const raisedRank = (
-      a: IVisibleParticipantInfo,
-      b: IVisibleParticipantInfo,
-    ) => {
-      const pa = queue.positions[a.userId];
-      const pb = queue.positions[b.userId];
-      if (pa && pb) return pa - pb;
-      if (pa) return -1;
-      if (pb) return 1;
-      return 0;
-    };
-
-    // .sort() mutates the array; `list` is already a filtered copy, so this is safe.
+    // Raised-hands-first ordering is an admin-only concern (managing the queue).
+    // Non-admins keep the baseline name order. .sort() mutates the array, but
+    // `list` is already a filtered copy, so this is safe.
     if (isAdmin) {
+      // Raised hands float to the top in queue order (matches the 1/2/3 badges).
+      // Returns 0 for non-raised pairs so the stable sort keeps the baseline name
+      // order (entity adapter sortComparer).
+      const raisedRank = (
+        a: IVisibleParticipantInfo,
+        b: IVisibleParticipantInfo,
+      ) => {
+        const pa = queue.positions[a.userId];
+        const pb = queue.positions[b.userId];
+        if (pa && pb) return pa - pb;
+        if (pa) return -1;
+        if (pb) return 1;
+        return 0;
+      };
+
       // waiting-room users stay on top, then raised hands, then the rest.
       return list.sort((a, b) => {
         if (a.waitForApproval !== b.waitForApproval) {
@@ -187,6 +189,6 @@ export const selectVisibleParticipants = createSelector(
         return raisedRank(a, b);
       });
     }
-    return list.sort(raisedRank);
+    return list;
   },
 );


### PR DESCRIPTION
Derives each raised hand's position from the new raised_hand_at timestamp and shows that number on the video-tile and participant-list indicators, but only once two or more hands are raised. 

In meetings with 10+ participants several hands often go up at once, so the numbered queue lets the host see the order and who's next instead of just an on/off indicator.