### PR TITLE
fix(chat): order messages by client-local arrival index instead of sender sentAt (#1062)

### DIFF
--- a/src/store/slices/chatMessagesSlice.ts
+++ b/src/store/slices/chatMessagesSlice.ts
@@ -10,6 +10,14 @@ interface ChatMessagesState {
   messageIds: {
     [messageId: string]: string; // messageId: key
   };
+  // Client-local, monotonically increasing arrival index used as the sort key
+  // instead of sentAt. sentAt is the *sender's* local clock (Date.now()), which
+  // is unreliable when participants' clocks are skewed and caused messages to be
+  // inserted into the middle of the history rather than appended (issue #1062).
+  messageOrder: {
+    [messageId: string]: number;
+  };
+  nextOrder: number;
 }
 
 const initialState: ChatMessagesState = {
@@ -17,6 +25,8 @@ const initialState: ChatMessagesState = {
     public: [],
   },
   messageIds: {},
+  messageOrder: {},
+  nextOrder: 0,
 };
 
 const getChatKey = (message: ChatMessage, currentUserId: string): string => {
@@ -29,11 +39,6 @@ const getChatKey = (message: ChatMessage, currentUserId: string): string => {
   } else {
     return message.fromUserId!;
   }
-};
-
-// Helper to ensure correct chronological sorting based on string timestamps
-const sortMessages = (a: ChatMessage, b: ChatMessage) => {
-  return Number(a.sentAt) - Number(b.sentAt);
 };
 
 const chatMessagesSlice = createSlice({
@@ -58,9 +63,13 @@ const chatMessagesSlice = createSlice({
         state.messages[key] = [];
       }
 
-      state.messages[key].push(message);
+      // Assign the next arrival index. Because it strictly increases in the
+      // order this client receives messages (which matches the server's relay
+      // order), the new message always belongs at the end — no re-sort needed,
+      // and a peer's skewed clock can no longer reorder existing messages.
+      state.messageOrder[message.id] = state.nextOrder++;
       state.messageIds[message.id] = key;
-      state.messages[key].sort(sortMessages);
+      state.messages[key].push(message);
     },
     addAllChatMessages: (
       state,
@@ -70,32 +79,31 @@ const chatMessagesSlice = createSlice({
       }>,
     ) => {
       const { messages, currentUserId } = action.payload;
-      const newMessagesByKey: { [key: string]: ChatMessage[] } = {};
 
-      // 1. Group all new messages by key, filtering out duplicates
-      messages.forEach((message) => {
-        if (state.messageIds[message.id]) {
-          return;
-        }
-        const key = getChatKey(message, currentUserId);
-        if (!newMessagesByKey[key]) {
-          newMessagesByKey[key] = [];
-        }
-        newMessagesByKey[key].push(message);
-      });
-
-      // 2. Merge, update IDs, and sort for each key that has new messages
-      Object.keys(newMessagesByKey).forEach((key) => {
-        const newMessages = newMessagesByKey[key];
-        if (!state.messages[key]) {
-          state.messages[key] = [];
-        }
-
-        state.messages[key].push(...newMessages);
-        newMessages.forEach((msg) => {
-          state.messageIds[msg.id] = key;
+      // Bootstrap path (e.g. persisted history). Live arrival order is unknown
+      // here, so seed the arrival index using sentAt as a best-effort ordering.
+      // This is the ONLY place sentAt still influences ordering, and it affects
+      // historical messages only — never live ones added via addChatMessage.
+      const affectedKeys = new Set<string>();
+      messages
+        .filter((message) => !state.messageIds[message.id])
+        .sort((a, b) => Number(a.sentAt) - Number(b.sentAt))
+        .forEach((message) => {
+          const key = getChatKey(message, currentUserId);
+          if (!state.messages[key]) {
+            state.messages[key] = [];
+          }
+          state.messageOrder[message.id] = state.nextOrder++;
+          state.messageIds[message.id] = key;
+          state.messages[key].push(message);
+          affectedKeys.add(key);
         });
-        state.messages[key].sort(sortMessages);
+
+      // Keep each touched conversation ordered by the arrival index.
+      affectedKeys.forEach((key) => {
+        state.messages[key].sort(
+          (a, b) => state.messageOrder[a.id] - state.messageOrder[b.id],
+        );
       });
     },
   },


### PR DESCRIPTION
## Problem

Chat messages are sorted by `sentAt`, which is set from the **sender's** local device clock (`Date.now()` in `ConnectNats.sendChatMsg`). When a participant's clock is skewed, their messages sort into the *middle* of the chat history on every client instead of appending at the end.

Fixes #1062.

## Root cause

`chatMessagesSlice` pushes each message and then re-sorts the whole conversation with `Number(a.sentAt) - Number(b.sentAt)`. Because `sentAt` comes from an untrusted, per-device clock, one skewed peer reorders history for everyone.

## Fix

Public/private chat is delivered over **core NATS pub/sub**, so every subscriber already receives messages in the server's relay order. This PR switches the sort key from `sentAt` to a **monotonically increasing, client-local arrival index** (`messageOrder` / `nextOrder`) assigned as each message enters the store:

- **`addChatMessage` (live path):** assign the next arrival index and append. The index strictly increases in receive order, so the message always belongs at the end — no re-sort, and a peer's clock can no longer reorder existing messages.
- **`addAllChatMessages` (bootstrap/history path):** live arrival order is unknown for already-persisted messages, so `sentAt` is used *only here* as a best-effort seed before assigning indices. This is the sole remaining place `sentAt` influences ordering, and it never affects live messages.

`sentAt` is untouched and still used for display.

## Notes / follow-up

This fully fixes the reported live-session symptom without any protocol or server change. The one residual limitation is history restored across skewed senders, whose *initial* seed still leans on `sentAt` (there is no better key available client-side). The complete fix for that case is server-authoritative timestamping in **plugNmeet-server** (option #1 in the issue), which is out of scope for this client-only change and worth a linked server-side issue.

## Test plan

1. Two participants join the same room; set one device's clock ±10 minutes.
2. Exchange messages both ways.
3. Confirm both clients show an identical, append-only order (no mid-list insertion).
4. Reload to confirm restored history renders in a sensible order.
