### PR TITLE
fix: dropdown icons were misplaced in RTL languages

### DIFF
--- a/src/components/app/index.tsx
+++ b/src/components/app/index.tsx
@@ -56,7 +56,8 @@ const App = () => {
   useEffect(() => {
     // make sure we're using correct body dir
     document.dir = i18n.dir();
-  }, [i18n, i18n.language]);
+    document.documentElement.lang = i18n.resolvedLanguage ?? i18n.language;
+  }, [i18n, i18n.language, i18n.resolvedLanguage]);
 
   useEffect(() => {
     void verifyToken(

--- a/src/components/chat/chatTabs.tsx
+++ b/src/components/chat/chatTabs.tsx
@@ -149,9 +149,9 @@ const ChatTabs = ({ isRecorder }: ChatTabsProps) => {
                 {selectedTitle}
               </span>
             </p>
-            <span className="pointer-events-none absolute inset-y-0 right-3 3xl:right-5 flex items-center">
+            <span className="pointer-events-none absolute inset-y-0 end-3 3xl:end-5 flex items-center">
               {hasUnreadMessages && (
-                <span className="shake pr-1 -mb-1">
+                <span className="shake pe-1 -mb-1">
                   <i className="pnm-chat shake" />
                 </span>
               )}

--- a/src/helpers/ui/dropdown.tsx
+++ b/src/helpers/ui/dropdown.tsx
@@ -47,7 +47,7 @@ const Dropdown = ({
           .map((text) => (
             <span
               key={text}
-              className="inline-block bg-Gray-100 dark:bg-dark-secondary2 text-Gray-800 dark:text-white text-xs font-medium mr-2 mb-1 px-2.5 py-1 rounded-full"
+              className="inline-block bg-Gray-100 dark:bg-dark-secondary2 text-Gray-800 dark:text-white text-xs font-medium me-2 mb-1 px-2.5 py-1 rounded-full"
             >
               {text}
             </span>
@@ -65,7 +65,7 @@ const Dropdown = ({
           {label && label !== '' && (
             <Label
               htmlFor={id}
-              className="pb-2 sm:pb-0 sm:pr-4 flex-1 text-sm text-Gray-950 ltr:text-left rtl:text-right dark:text-white"
+              className="pb-2 sm:pb-0 sm:pe-4 flex-1 text-sm text-Gray-950 text-start dark:text-white"
             >
               {label}
             </Label>
@@ -81,7 +81,7 @@ const Dropdown = ({
             >
               <ListboxButton
                 id={id}
-                className={`min-h-10 full cursor-pointer rounded-[8px] border border-Gray-300 dark:border-Gray-800 bg-white shadow-input w-full px-3 py-1 outline-hidden focus:border-[rgba(0,161,242,1)] focus:shadow-input-focus text-left text-sm dark:bg-transparent dark:text-white ${
+                className={`min-h-10 full cursor-pointer rounded-[8px] border border-Gray-300 dark:border-Gray-800 bg-white shadow-input w-full px-3 py-1 outline-hidden focus:border-[rgba(0,161,242,1)] focus:shadow-input-focus text-start text-sm dark:bg-transparent dark:text-white ${
                   disabled ? 'opacity-50 cursor-not-allowed' : ''
                 }`}
               >
@@ -90,7 +90,7 @@ const Dropdown = ({
                     <span className="text-Gray-500">{/* Placeholder */}</span>
                   )}
                 </div>
-                <span className="pointer-events-none absolute inset-y-0 right-4 flex items-center">
+                <span className="pointer-events-none absolute inset-y-0 end-4 flex items-center">
                   <DropdownIconSVG />
                 </span>
               </ListboxButton>
@@ -102,7 +102,7 @@ const Dropdown = ({
               >
                 <ListboxOptions
                   static
-                  className="absolute z-20 mt-1 max-h-60 w-72 ltr:right-0 rtl:left-0 overflow-auto rounded-[15px] bg-white p-1 text-sm shadow-dropdown-menu border border-Gray-100 dark:border-Gray-800 focus:outline-hidden scrollBar scrollBar2 grid gap-0.5 dark:bg-dark-secondary"
+                  className="absolute z-20 mt-1 max-h-60 w-72 end-0 overflow-auto rounded-[15px] bg-white p-1 text-sm shadow-dropdown-menu border border-Gray-100 dark:border-Gray-800 focus:outline-hidden scrollBar scrollBar2 grid gap-0.5 dark:bg-dark-secondary"
                 >
                   {options.map((option) => (
                     <ListboxOption
@@ -122,7 +122,7 @@ const Dropdown = ({
                             {option.text}
                           </span>
                           {selected && (
-                            <span className="absolute inset-y-0 right-0 flex items-center pr-3 text-Blue2-500 dark:text-white">
+                            <span className="absolute inset-y-0 end-0 flex items-center pe-3 text-Blue2-500 dark:text-white">
                               <CheckMarkIcon />
                             </span>
                           )}
@@ -145,7 +145,7 @@ const Dropdown = ({
       {label && label !== '' && (
         <Label
           htmlFor={id}
-          className="w-full text-sm font-medium text-Gray-800 ltr:text-left rtl:text-right mb-2 block dark:text-white"
+          className="w-full text-sm font-medium text-Gray-800 text-start mb-2 block dark:text-white"
         >
           {label}
         </Label>
@@ -159,7 +159,7 @@ const Dropdown = ({
         <div className="relative w-full">
           <ListboxButton
             id={id}
-            className={`min-h-10 full cursor-pointer rounded-[8px] border border-Gray-300 dark:border-Gray-800 bg-white shadow-input w-full px-3 py-1 outline-hidden focus:border-[rgba(0,161,242,1)] focus:shadow-input-focus text-left text-sm dark:bg-transparent dark:text-white ${
+            className={`min-h-10 full cursor-pointer rounded-[8px] border border-Gray-300 dark:border-Gray-800 bg-white shadow-input w-full px-3 py-1 outline-hidden focus:border-[rgba(0,161,242,1)] focus:shadow-input-focus text-start text-sm dark:bg-transparent dark:text-white ${
               disabled ? 'opacity-50 cursor-not-allowed' : ''
             }`}
           >
@@ -168,7 +168,7 @@ const Dropdown = ({
                 <span className="text-Gray-500">{/* Placeholder */}</span>
               )}
             </div>
-            <span className="pointer-events-none absolute inset-y-0 right-4 flex items-center">
+            <span className="pointer-events-none absolute inset-y-0 end-4 flex items-center">
               <DropdownIconSVG />
             </span>
           </ListboxButton>
@@ -180,7 +180,7 @@ const Dropdown = ({
           >
             <ListboxOptions
               static
-              className="absolute z-20 mt-1 max-h-60 w-full ltr:right-0 rtl:left-0 overflow-auto rounded-[15px] bg-white p-1 text-sm shadow-dropdown-menu border border-Gray-100 dark:border-Gray-800 focus:outline-hidden scrollBar scrollBar2 grid gap-0.5 dark:bg-dark-secondary"
+              className="absolute z-20 mt-1 max-h-60 w-full end-0 overflow-auto rounded-[15px] bg-white p-1 text-sm shadow-dropdown-menu border border-Gray-100 dark:border-Gray-800 focus:outline-hidden scrollBar scrollBar2 grid gap-0.5 dark:bg-dark-secondary"
             >
               {options.map((option) => (
                 <ListboxOption
@@ -198,7 +198,7 @@ const Dropdown = ({
                     <>
                       <span className={`block truncate`}>{option.text}</span>
                       {selected && (
-                        <span className="absolute inset-y-0 right-0 flex items-center pr-3 text-Blue2-500 dark:text-white">
+                        <span className="absolute inset-y-0 end-0 flex items-center pe-3 text-Blue2-500 dark:text-white">
                           <CheckMarkIcon />
                         </span>
                       )}


### PR DESCRIPTION
# fix: dropdown icons were misplaced in RTL languages

## Problem

When the UI language is switched to an RTL locale — `fa-IR`, `ar-SA`, `he-IL` —
`document.dir` correctly flips to `rtl` and the layout mirrors, but the icons
inside the shared `Dropdown` component do not follow. The chevron stays pinned
to the right edge and ends up rendered on top of the selected value.

Reproduce: join a room → **⋮ → Settings → Application → Language** → pick
**فارسی** (or **اللغة العربية**). The chevron now overlaps the label text.

## Cause

`src/helpers/ui/dropdown.tsx` positions the chevron and the selected-option
check-mark with **physical** direction utilities:

```
absolute inset-y-0 right-4          // chevron
absolute inset-y-0 right-0 pr-3     // check-mark
text-left                           // button label
mr-2  /  sm:pr-4                    // chip margin, label padding
```

`right-*`, `pr-*`, `mr-*` and `text-left` resolve to the physical right/left
edge regardless of `dir`, so they do not mirror with the rest of the layout.

The same component also carried `ltr:right-0 rtl:left-0` and
`ltr:text-left rtl:text-right` pairs — correct, but redundant now that Tailwind
v4 logical utilities are available.

## Fix

Swap the physical utilities for their logical equivalents, which resolve
against the inline direction:

| Before | After |
|---|---|
| `right-4` | `end-4` |
| `right-0` | `end-0` |
| `pr-3` | `pe-3` |
| `sm:pr-4` | `sm:pe-4` |
| `mr-2` | `me-2` |
| `text-left` | `text-start` |
| `ltr:right-0 rtl:left-0` | `end-0` |
| `ltr:text-left rtl:text-right` | `text-start` |

`src/helpers/ui/dropdown.tsx` now contains no physical direction utilities at
all. The identical chevron bug in `src/components/chat/chatTabs.tsx` is fixed
the same way.

**LTR rendering is unchanged** — in LTR, `end-*` resolves to exactly the same
edge as `right-*`.

Additionally, `document.documentElement.lang` is now set alongside
`document.dir` in `src/components/app/index.tsx`. It previously stayed at
`"en"` after a language change, which misleads screen readers and browser
hyphenation.

## Verification

`pnpm lint` and `pnpm build` both pass.

Measured from the DOM in a live room, on the Language dropdown — chevron
position relative to the button, and whether it overlaps the label glyphs:

| Language | `dir` | Chevron side | Inset from edge | Overlaps label |
|---|---|---|---|---|
| English | `ltr` | right | 15px | no |
| فارسی | `rtl` | left | 15px | no |
| اللغة العربية | `rtl` | left | 15px | no |

The identical 15px inset across all three confirms LTR is untouched and RTL is
now its exact mirror. The open options panel and the check-mark were checked
too: both align to the inline-end edge, matching the previous
`ltr:/rtl:` behaviour.

## Scope

This PR deliberately stays inside the two components involved in the bug. The
wider codebase still uses physical direction utilities in many places
(~81 `right-*`, ~149 `left-*`, ~47 `pl-*`), so other RTL layout issues almost
certainly remain. Happy to open a follow-up PR for a broader audit if that
direction is welcome — it seemed better to keep this one reviewable.
